### PR TITLE
Fallback to downloading via file_get_contents() if curl is not availible

### DIFF
--- a/simpleCache.php
+++ b/simpleCache.php
@@ -58,14 +58,20 @@ class SimpleCache {
 	//Helper function for retrieving data from url
 	function do_curl($url)
 	{
-		$ch = curl_init();
-		curl_setopt($ch, CURLOPT_URL, $url);
-		curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1); 
-		curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 1);
-		$content = curl_exec($ch);
-		curl_close($ch);
-		
+		if(function_exists("curl_init"))
+		{
+			$ch = curl_init();
+			curl_setopt($ch, CURLOPT_URL, $url);
+			curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1); 
+			curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 1);
+			$content = curl_exec($ch);
+			curl_close($ch);
+			
 		return $content;
+		}
+		else {
+			return file_get_contents($url);
+		}
 	}
 	
 	//Helper function to validate filenames


### PR DESCRIPTION
Hi, 
I have included a little condition, so that it deos not fail if no curl is availible: If curl is installed, use it, and if not, just use file_get_contents(). This will allow to easily fetch remote content. However, it stll doesn't work if allow_url_fopen is disabled, and it could fetch local files too, but the only other solution would be some (for this simple class) overkill socket logic. 
